### PR TITLE
Updating the workflow and contributing documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,15 +1,7 @@
-# Local workflow
+![BlueFinch Checkout](../assets/logo.svg)
 
-When you install the module it will be able to read from the generated `dist` but for making change it is best to use the `watch` functionality.
+# BlueFinch Checkout - Contributing
 
-Turn on support for vite watch in the admin panel or by using magerun
-- `BlueFinch -> Checkout -> General -> Enable local developer vite watch mode = yes`
-- `n98-magerun config:store:set bluefinchcommerce_checkout/general/enable_local_developer_vite_watch_mode=1`
+We welcome contributions to any of the BlueFinch Checkout modules.
 
-```bash
-cd view/frontend/web/js/checkout/ # or view/adminhtml/web/js/checkout/
-npm ci
-npm run build-watch
-```
-
-This will populate `view/frontend/web/js/checkout/dist-dev` for use, allowing you to make changes and have them quickly visible on the frontend.
+Please refer to the [BlueFinch Checkout contributing guidelines](https://github.com/BlueFinchCommerce/module-checkout/blob/main/.github/CONTRIBUTING.md) that apply to both the core module and any extension modules, such as this one.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Remember to clear any appropriate caches.
 
 Once installed the module follows the same configuration settings as prescribed by the official rvvup integration documentation, see [Rvvup for Magento](https://help.rvvup.com/hc/en-gb/articles/13742786115217-Rvvup-for-Magento-Installation-Guide).
 
+## Local frontend development workflow
+
+Please refer to the local frontend development workflow section of the [BlueFinch Checkout contributing guidelines](https://github.com/BlueFinchCommerce/module-checkout/blob/main/.github/CONTRIBUTING.md), that applies to all BlueFinch Checkout extension modules, such as this one.
+
 ## CircleCi
 
 CircleCi is a tool for us to use to allow for tested to be run on our modules before they are deployed.


### PR DESCRIPTION
Removing the FE workflow documentation from the contributing doc and adding references to the same information on the core checkout module to reduce duplication for future documentation amends.