### PR TITLE
Render inline scripts with secure renderer to PCI DSS v4 compliance

### DIFF
--- a/view/frontend/templates/rvvup.phtml
+++ b/view/frontend/templates/rvvup.phtml
@@ -3,6 +3,7 @@
  * @var \Magento\Framework\View\Element\Template $block
  * @var \Magento\Framework\Escaper $escaper
  * @var \BlueFinch\Checkout\ViewModel\Assets $assetViewModel
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 
 $assetViewModel = $block->getAssetViewModel();
@@ -12,11 +13,12 @@ $styles = $assetViewModel->getDistViewFileUrl('BlueFinch_CheckoutRvvup::js/check
 
 ?>
 
-<script>
+<?php $scriptString = <<<script
     window.bluefinchCheckout = window.bluefinchCheckout || {};
     window.bluefinchCheckout.paymentMethods = window.bluefinchCheckout.paymentMethods || {};
 
-    window.bluefinchCheckout.paymentMethods.Rvvup = "<?= $escaper->escapeJs($payByBank) ?>";
-</script>
+    window.bluefinchCheckout.paymentMethods.Rvvup = "{$escaper->escapeJs($payByBank)}";
+script; ?>
+<?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
 
 <link rel="stylesheet" href="<?= $escaper->escapeHtmlAttr($styles) ?>" />


### PR DESCRIPTION
As with the main checkout module to pass PCI DSS v4 compliance all inline scripts must be rendered with Adobe Commerce's secure renderer.

See https://github.com/BlueFinchCommerce/module-checkout/pull/54